### PR TITLE
Separate command and arguments into separate fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,23 +26,22 @@ fn duration_to_string(duration: Duration, pretty: bool) -> String {
     }
 }
 
-fn initialize(args: &Vec<String>) {
-    let mut command = String::from("timit");
-    for arg in args {
+fn initialize(args: &Args) {
+    let mut command = format!("timit {}", args.command);
+    for arg in &args.command_args {
         command.push_str(&format!(" {}", arg));
     }
     println!("Command: {}", command);
 }
 
 fn observe_process(args: &Args) -> (bool, Result<Duration, &str>) {
-    let process_args: Vec<&String> = args.command.iter().skip(1).collect();
-    let mut command = Command::new(&args.command[0]);
-    command.args(process_args);
+    let mut command = Command::new(&args.command);
+    command.args(&args.command_args);
     if !args.borrow_stdio {
         command
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null());
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .stdin(Stdio::null());
     }
     let start_time = Instant::now();
     let mut child = match command.spawn() {
@@ -54,10 +53,7 @@ fn observe_process(args: &Args) -> (bool, Result<Duration, &str>) {
     let success = match child.wait() {
         Ok(status) => status.success(),
         Err(_) => {
-            return (
-                true,
-                Err("Could not collect timed process exit status"),
-            );
+            return (true, Err("Could not collect timed process exit status"));
         }
     };
     let end_time = Instant::now();
@@ -72,12 +68,15 @@ fn observe_process(args: &Args) -> (bool, Result<Duration, &str>) {
 
 fn print_results(args: &Args, duration: Duration) {
     println!("Results:");
-    println!("  Duration: {}", duration_to_string(duration, !args.display_nanos));
+    println!(
+        "  Duration: {}",
+        duration_to_string(duration, !args.display_nanos)
+    );
     println!();
 }
 
 fn run(args: Args) {
-    initialize(&args.command);
+    initialize(&args);
     println!("-- Begin program output --");
     let (success, duration_result) = observe_process(&args);
     println!("--- End program output ---");
@@ -85,57 +84,56 @@ fn run(args: Args) {
         println!("Note: Process exit status indicated failure");
     }
     match duration_result {
-        Ok(duration) => {
-            print_results(&args, duration);
-        }
-        Err(reason) => {
-            println!("Error: {}", reason);
-        }
+        Ok(duration) => print_results(&args, duration),
+        Err(reason) => println!("Error: {}", reason),
     }
 }
 
 struct Args {
     display_nanos: bool,
     borrow_stdio: bool,
-    command: Vec<String>
+    command: String,
+    command_args: Vec<String>,
 }
 
 fn parse_args(args: Vec<String>) -> Result<Args, &'static str> {
     let mut iter = args.into_iter();
     let mut display_nanos = false;
     let mut borrow_stdio = true;
-    let mut command = vec![];
+    let mut command = None;
     loop {
         let arg = match iter.next() {
-            None => { break }
-            Some(arg) => { arg }
+            None => break,
+            Some(arg) => arg,
         };
         if arg == String::from("--nanos") {
             display_nanos = true;
         } else if arg == String::from("--hide-stdio") {
             borrow_stdio = false;
         } else if arg == String::from("--prog") {
+            command = iter.next();
             break;
         } else {
-            command.push(arg);
+            command = Some(arg);
             break;
         }
     }
-    command.extend(iter);
-    match command.len() {
-        0 => { Err("No command specified") }
-        _ => Ok(Args {
+    let command_args = iter.collect();
+    match command {
+        None => Err("No command specified"),
+        Some(command) => Ok(Args {
             display_nanos,
             borrow_stdio,
             command,
-        })
+            command_args,
+        }),
     }
 }
 
 fn main() {
     let args: Vec<_> = std::env::args().skip(1).collect();
     match parse_args(args) {
-        Err(msg) => { eprintln!("Error: {}", msg)}
-        Ok(args) => run(args)
+        Err(msg) => eprintln!("Error: {}", msg),
+        Ok(args) => run(args),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn parse_args(args: Vec<String>) -> Result<Args, &'static str> {
 }
 
 fn main() {
-    let args: Vec<_> = std::env::args().skip(1).collect();
+    let args = std::env::args().skip(1).collect();
     match parse_args(args) {
         Err(msg) => eprintln!("Error: {}", msg),
         Ok(args) => run(args),

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,15 +46,11 @@ fn observe_process(args: &Args) -> (bool, Result<Duration, &str>) {
     let start_time = Instant::now();
     let mut child = match command.spawn() {
         Ok(child) => child,
-        Err(_) => {
-            return (true, Err("Could not spawn timed process"));
-        }
+        Err(_) => return (true, Err("Could not spawn timed process")),
     };
     let success = match child.wait() {
         Ok(status) => status.success(),
-        Err(_) => {
-            return (true, Err("Could not collect timed process exit status"));
-        }
+        Err(_) => return (true, Err("Could not collect timed process exit status")),
     };
     let end_time = Instant::now();
 


### PR DESCRIPTION
- `Args.command` was a `Vec<String>` which stored the command to run and its arguments.
- Splitting apart the command into its own field allowed for simpler matching and error checking.
---
Additional changes:
- Refactored match expressions to be more idiomatic
- Removed inferable type annotations