### PR TITLE
Improvements to result reporting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn parse_args(args: Vec<String>) -> MsgResult<'static, Args> {
 fn main() {
     let args = std::env::args().skip(1).collect();
     match parse_args(args) {
-        Err(msg) => eprintln!("Error: {}", msg),
+        Err(msg) => println!("Error: {}", msg),
         Ok(args) => run(args),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-fn duration_to_string(duration: Result<Duration, &str>, pretty: bool) -> String {
+fn duration_to_string(duration: MsgResult<Duration>, pretty: bool) -> String {
     if let Err(msg) = duration {
         return String::from(msg);
     }
@@ -37,7 +37,7 @@ fn initialize(args: &Args) {
     println!("Command: {}", command);
 }
 
-fn observe_process(args: &Args) -> Result<ProcessResults, &str> {
+fn observe_process(args: &Args) -> MsgResult<ProcessResults> {
     let mut command = Command::new(&args.command);
     command.args(&args.command_args);
     if !args.borrow_stdio {
@@ -102,10 +102,12 @@ struct Args {
 
 struct ProcessResults<'a> {
     success: bool,
-    duration: Result<Duration, &'a str>,
+    duration: MsgResult<'a, Duration>,
 }
 
-fn parse_args(args: Vec<String>) -> Result<Args, &'static str> {
+type MsgResult<'a, T> = Result<T, &'a str>;
+
+fn parse_args(args: Vec<String>) -> MsgResult<'static, Args> {
     let mut iter = args.into_iter();
     let mut display_nanos = false;
     let mut borrow_stdio = true;


### PR DESCRIPTION
- Added new types to better represent domain:
  - `ProcessResults` to hold the results of a command run
  - `MsgResult` to more succinctly model domain errors
- Improvements to exit status reporting
  - Now displays in "Results" section
  - Display exit code in addition to success/failure
---
Additional changes:
- Replace calls to `eprintln!` with `println!` so that all output will go to `stdout`