### PR TITLE
Ignore /misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/misc


### PR DESCRIPTION
Ignore the `misc` folder, which can be used to store and edit local, incidental, project-related files without getting in the way of git. Currently used to store `ideas.md`, my local brainstorming file.