### PR TITLE
Add crate Error and Result types

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,7 @@ fn initialize(args: &Args, writer: &mut impl Write) -> io::Result<()> {
     writeln!(writer, "Command: {}", command)
 }
 
-fn print_results(args: &Args, results: ProcessResults, writer: &mut impl Write) -> io::Result<()> {
+fn print_results(args: &Args, results: ProcessData, writer: &mut impl Write) -> io::Result<()> {
     writeln!(writer, "Results:")?;
     writeln!(
         writer,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,9 +113,9 @@ fn exit_status_to_string(status: ExitStatus) -> String {
     format!("{} ({})", code, explanation)
 }
 
-fn duration_to_string(duration: MsgResult<Duration>, pretty: bool) -> String {
-    if let Err(msg) = duration {
-        return String::from(msg);
+fn duration_to_string(duration: Option<Duration>, pretty: bool) -> String {
+    if let None = duration {
+        return String::from("There was an error timing the operation.");
     }
     let total_nanos = duration.unwrap().as_nanos();
     if pretty {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -34,3 +34,13 @@ fn stream_or_null(file: Option<std::fs::File>) -> Stdio {
         None => Stdio::inherit(),
     }
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            Error::NotSpawned => String::from("Could not spawn timed process"),
+            Error::NotJoined => String::from("Could not collect timed process exit status"),
+        };
+        write!(f, "{}", reason)
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -38,8 +38,8 @@ fn stream_or_null(file: Option<std::fs::File>) -> Stdio {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let reason = match self {
-            Error::NotSpawned => String::from("Could not spawn timed process"),
-            Error::NotJoined => String::from("Could not collect timed process exit status"),
+            Error::NotSpawned => String::from("could not spawn process"),
+            Error::NotJoined => String::from("could not observe process exit"),
         };
         write!(f, "{}", reason)
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 use types::*;
 
-pub fn observe_process(args: &Args, io: IOArgs) -> Rsult<ProcessResults> {
+pub fn observe_process(args: &Args, io: IOArgs) -> Result<ProcessResults> {
     let mut command = Command::new(&args.command);
     command
         .args(&args.command_args)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 use types::*;
 
-pub fn observe_process(args: &Args, io: IOArgs) -> Result<ProcessResults> {
+pub fn observe_process(args: &Args, io: IOArgs) -> Result<ProcessData> {
     let mut command = Command::new(&args.command);
     command
         .args(&args.command_args)
@@ -21,7 +21,7 @@ pub fn observe_process(args: &Args, io: IOArgs) -> Result<ProcessResults> {
     };
     let end_time = Instant::now();
 
-    Ok(ProcessResults {
+    Ok(ProcessData {
         exit_status,
         duration: end_time
             .checked_duration_since(start_time),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use std::time::Instant;
 use types::*;
 
-pub fn observe_process(args: &Args, io: IOArgs) -> MsgResult<ProcessResults> {
+pub fn observe_process(args: &Args, io: IOArgs) -> Rsult<ProcessResults> {
     let mut command = Command::new(&args.command);
     command
         .args(&args.command_args)
@@ -13,19 +13,18 @@ pub fn observe_process(args: &Args, io: IOArgs) -> MsgResult<ProcessResults> {
     let start_time = Instant::now();
     let mut child = match command.spawn() {
         Ok(child) => child,
-        Err(_) => return Err("Could not spawn timed process"),
+        Err(_) => return Err(Error::NotSpawned),
     };
     let exit_status = match child.wait() {
         Ok(status) => status,
-        Err(_) => return Err("Could not collect timed process exit status"),
+        Err(_) => return Err(Error::NotJoined),
     };
     let end_time = Instant::now();
 
     Ok(ProcessResults {
         exit_status,
         duration: end_time
-            .checked_duration_since(start_time)
-            .ok_or("There was an error timing the operation."),
+            .checked_duration_since(start_time),
     })
 }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::io;
 use std::process::ExitStatus;
 use std::time::Duration;
 
@@ -37,4 +36,4 @@ impl std::fmt::Display for Error {
     }
 }
 
-pub type Rsult<T> = Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -26,14 +26,4 @@ pub enum Error {
     NotJoined,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let reason = match self {
-            Error::NotSpawned => String::from("Could not spawn timed process"),
-            Error::NotJoined => String::from("Could not collect timed process exit status"),
-        };
-        write!(f, "{}", reason)
-    }
-}
-
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -17,16 +17,24 @@ pub struct IOArgs {
     pub stderr: Option<File>,
 }
 
-pub struct ProcessResults<'a> {
+pub struct ProcessResults {
     pub exit_status: ExitStatus,
-    pub duration: MsgResult<'a, Duration>,
+    pub duration: Option<Duration>,
 }
 
 pub enum Error {
-    IO(io::Error),
     NotSpawned,
     NotJoined,
-    Timing,
 }
 
-pub type MsgResult<'a, T> = Result<T, &'a str>;
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self {
+            Error::NotSpawned => String::from("Could not spawn timed process"),
+            Error::NotJoined => String::from("Could not collect timed process exit status"),
+        };
+        write!(f, "{}", reason)
+    }
+}
+
+pub type Rsult<T> = Result<T, Error>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io;
 use std::process::ExitStatus;
 use std::time::Duration;
 
@@ -19,6 +20,13 @@ pub struct IOArgs {
 pub struct ProcessResults<'a> {
     pub exit_status: ExitStatus,
     pub duration: MsgResult<'a, Duration>,
+}
+
+pub enum Error {
+    IO(io::Error),
+    NotSpawned,
+    NotJoined,
+    Timing,
 }
 
 pub type MsgResult<'a, T> = Result<T, &'a str>;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -16,7 +16,7 @@ pub struct IOArgs {
     pub stderr: Option<File>,
 }
 
-pub struct ProcessResults {
+pub struct ProcessData {
     pub exit_status: ExitStatus,
     pub duration: Option<Duration>,
 }


### PR DESCRIPTION
- Adds `Error` type to represent various things that could go wrong.
  - Should allow for cleaner code and less string handling.
- Improved error message style, content, and consistency.
- Adds `Result` type to incorporate `Error`.
  - This is a more mature replacement for `MsgResult`.
- Renamed `ProcessResults` to `ProcessData` to alleviate potential confusion.
  - Changed `duration` field from `MsgResult<Duration>` to `Option<Duration>`.
    - Remove a needless wrapper layer.