### PR TITLE
Fix formatting and add format-on-save support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust"
+  }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,8 +23,7 @@ pub fn observe_process(args: &Args, io: IOArgs) -> Result<ProcessData> {
 
     Ok(ProcessData {
         exit_status,
-        duration: end_time
-            .checked_duration_since(start_time),
+        duration: end_time.checked_duration_since(start_time),
     })
 }
 


### PR DESCRIPTION
- Fix formatting in `master`.
  - Introduced in #9.
- Add `cargo fmt` format-on-save support to VS Code.