### PR TITLE
Add null IO option and IO refactor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,6 @@ impl CLIArgs {
         Ok((
             Args {
                 display_nanos: self.nanos,
-                borrow_stdio: true,
                 command: command_iter.next().unwrap(), // failsafe due to #[structopt(required = true)]
                 command_args: command_iter.collect(),
             },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,28 +17,16 @@ struct CLIArgs {
     nanos: bool,
 
     /// Set stdin for the spawned process
-    #[structopt(short = "i", long, conflicts_with_all(&["stdin_null", "stdin_inherit"]))]
+    #[structopt(short = "i", long, conflicts_with = "stdin_inherit")]
     stdin: Option<String>,
 
     /// Set stdout for the spawned process
-    #[structopt(short = "o", long, conflicts_with_all(&["stdout_null", "stdout_inherit"]))]
+    #[structopt(short = "o", long, conflicts_with = "stdout_inherit")]
     stdout: Option<String>,
 
     /// Set stderr for the spawned process
-    #[structopt(short = "e", long, conflicts_with_all(&["stderr_null", "stderr_inherit"]))]
+    #[structopt(short = "e", long, conflicts_with = "stderr_inherit")]
     stderr: Option<String>,
-
-    /// Set stdin to null
-    #[structopt(long, conflicts_with = "stdin_inherit")]
-    stdin_null: bool,
-
-    /// Set stdout to null
-    #[structopt(long, conflicts_with = "stdout_inherit")]
-    stdout_null: bool,
-
-    /// Set stderr to null
-    #[structopt(long, conflicts_with = "stderr_inherit")]
-    stderr_null: bool,
 
     /// Inherit stdin from the current process
     #[structopt(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,30 @@ struct CLIArgs {
     #[structopt(short = "e", long)]
     stderr: Option<String>,
 
+    /// Set stdin to null
+    #[structopt(long)]
+    stdin_null: bool,
+
+    /// Set stdout to null
+    #[structopt(long)]
+    stdout_null: bool,
+
+    /// Set stderr to null
+    #[structopt(long)]
+    stderr_null: bool,
+
+    /// Inherit stdin from the current process
+    #[structopt(long)]
+    stdin_inherit: bool,
+
+    /// Inherit stdout from the current process
+    #[structopt(long)]
+    stdout_inherit: bool,
+
+    /// Inherit stderr from the current process
+    #[structopt(long)]
+    stderr_inherit: bool,
+
     /// The command to spawn followed by its arguments
     #[structopt(required = true)]
     command: Vec<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,27 +17,27 @@ struct CLIArgs {
     nanos: bool,
 
     /// Set stdin for the spawned process
-    #[structopt(short = "i", long, conflicts_with = "stdin_null")]
+    #[structopt(short = "i", long)]
     stdin: Option<String>,
 
     /// Set stdout for the spawned process
-    #[structopt(short = "o", long, conflicts_with = "stdout_null")]
+    #[structopt(short = "o", long)]
     stdout: Option<String>,
 
     /// Set stderr for the spawned process
-    #[structopt(short = "e", long, conflicts_with = "stderr_null")]
+    #[structopt(short = "e", long)]
     stderr: Option<String>,
 
     /// Set stdin to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stdin")]
     stdin_null: bool,
 
     /// Set stdout to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stdout")]
     stdout_null: bool,
 
     /// Set stderr to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stderr")]
     stderr_null: bool,
 
     /// The command to spawn followed by its arguments

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,7 @@ impl CLIArgs {
     }
 
     pub fn to_args(self) -> io::Result<(Args, IOArgs)> {
+        // TODO remove hardcoded false for inherit
         let stdin = CLIArgs::to_io_stream(false, self.stdin, true)?;
         let stdout = CLIArgs::to_io_stream(false, self.stdout, false)?;
         let stderr = CLIArgs::to_io_stream(false, self.stderr, false)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,10 +78,9 @@ impl CLIArgs {
     }
 
     pub fn to_args(self) -> io::Result<(Args, IOArgs)> {
-        // TODO remove hardcoded false for inherit
-        let stdin = CLIArgs::to_io_stream(false, self.stdin, true)?;
-        let stdout = CLIArgs::to_io_stream(false, self.stdout, false)?;
-        let stderr = CLIArgs::to_io_stream(false, self.stderr, false)?;
+        let stdin = CLIArgs::to_io_stream(self.stdin_inherit, self.stdin, true)?;
+        let stdout = CLIArgs::to_io_stream(self.stdout_inherit, self.stdout, false)?;
+        let stderr = CLIArgs::to_io_stream(self.stderr_inherit, self.stderr, false)?;
         let mut command_iter = self.command.into_iter();
         Ok((
             Args {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,27 +17,27 @@ struct CLIArgs {
     nanos: bool,
 
     /// Set stdin for the spawned process
-    #[structopt(short = "i", long)]
+    #[structopt(short = "i", long, conflicts_with_all(&["stdin_null", "stdin_inherit"]))]
     stdin: Option<String>,
 
     /// Set stdout for the spawned process
-    #[structopt(short = "o", long)]
+    #[structopt(short = "o", long, conflicts_with_all(&["stdout_null", "stdout_inherit"]))]
     stdout: Option<String>,
 
     /// Set stderr for the spawned process
-    #[structopt(short = "e", long)]
+    #[structopt(short = "e", long, conflicts_with_all(&["stderr_null", "stderr_inherit"]))]
     stderr: Option<String>,
 
     /// Set stdin to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stdin_inherit")]
     stdin_null: bool,
 
     /// Set stdout to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stdout_inherit")]
     stdout_null: bool,
 
     /// Set stderr to null
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "stderr_inherit")]
     stderr_null: bool,
 
     /// Inherit stdin from the current process

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -26,10 +26,11 @@ fn build_command(args: &Args, io: IOArgs) -> Command {
     command
 }
 
-fn stream_or_null(file: Option<std::fs::File>) -> Stdio {
-    match file {
-        Some(file) => Stdio::from(file),
-        None => Stdio::inherit(),
+fn stream_or_null(stream: IOStream) -> Stdio {
+    match stream {
+        Null => Stdio::null(),
+        Inherit => Stdio::inherit(),
+        IOStream::File(file) => Stdio::from(file),
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,8 +28,8 @@ fn build_command(args: &Args, io: IOArgs) -> Command {
 
 fn stream_or_null(stream: IOStream) -> Stdio {
     match stream {
-        Null => Stdio::null(),
-        Inherit => Stdio::inherit(),
+        IOStream::Null => Stdio::null(),
+        IOStream::Inherit => Stdio::inherit(),
         IOStream::File(file) => Stdio::from(file),
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -11,9 +11,15 @@ pub struct Args {
 }
 
 pub struct IOArgs {
-    pub stdin: Option<File>,
-    pub stdout: Option<File>,
-    pub stderr: Option<File>,
+    pub stdin: IOStream,
+    pub stdout: IOStream,
+    pub stderr: IOStream,
+}
+
+pub enum IOStream {
+    Null,
+    Inherit,
+    File(File),
 }
 
 pub struct ProcessData {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -4,8 +4,6 @@ use std::time::Duration;
 
 pub struct Args {
     pub display_nanos: bool,
-    /// Ignored for now
-    pub borrow_stdio: bool,
     pub command: String,
     pub command_args: Vec<String>,
 }


### PR DESCRIPTION
This PR adds the ability to specify null IO streams.

- New `IOStream` type to represent three possible io methods:
  - `Inherit`: Use timit's I/O stream. This is the default.
  - `Null`: Use a null stream. This is set with the `--stdx-null` flag.
  - `File(File)`: Use the specified file. This is set with the `--stdx` flag as in the status quo.
- Add conflict rules to clap so that matching null and file flags cannot be used together.

---

Additional changes:

- Remove the internal and now superseded `--borrow-stdio`-flag-related logic